### PR TITLE
Use .Permalink instead of hard-coding the search page

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -6,7 +6,7 @@
 {{ define "main" }}
 <section class="resume-section p-3 p-lg-5 d-flex flex-column">
   <div class="my-auto" >
-    <form action="{{ "search" | absURL }}">
+    <form action="{{ .Permalink }}">
       <input id="search-query" name="s"/>
     </form>
     <div id="search-results">


### PR DESCRIPTION
Using .Permalink, we do not have to worry if the user decides to rename search.md to foo.md.