### PR TITLE
fix: remove email substring

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -9,7 +9,7 @@
                 <span class="text-primary">{{ .Site.Params.lastName }}</span>
               </h1>
               <div class="subheading mb-5">{{ .Site.Params.address }} ·
-                <a href="mailto:{{ substr .Site.Params.email 0 5}}-remove-{{ substr .Site.Params.email 5 }}">{{ substr .Site.Params.email 0 5}}<span style="display:none">-remove-</span>{{ substr .Site.Params.email 5 }}</a>
+                <a href="mailto:{{ .Site.Params.email }}">{{ .Site.Params.email }}</a>
               </div>
 
             </div>


### PR DESCRIPTION
Fixes issue where emails are broken into a substring with `-remove-` added on the mailto link.