### PR TITLE
[fix] Remove unnecessary words in mailto

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -9,7 +9,7 @@
                 <span class="text-primary">{{ .Site.Params.lastName }}</span>
               </h1>
               <div class="subheading mb-5">{{ .Site.Params.address }} ·
-                <a href="mailto:{{ substr .Site.Params.email 0 5}}-remove-{{ substr .Site.Params.email 5 }}">{{ substr .Site.Params.email 0 5}}<span style="display:none">-remove-</span>{{ substr .Site.Params.email 5 }}</a>
+                <a href="mailto:{{ substr .Site.Params.email 0 5}}{{ substr .Site.Params.email 5 }}">{{ substr .Site.Params.email 0 5}}{{ substr .Site.Params.email 5 }}</a>
               </div>
 
             </div>


### PR DESCRIPTION
I writed my mail address(`hogehoge@example.com`) to `email` of `config.toml`.

After, I saw a wrong mail address  `hogeh-remove-oge@example.com` when I click the email address in about page.

So, I made this PR.

Please checking this..!