### PR TITLE
Replace deprecated .Hugo function

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,7 +20,7 @@
   <!-- Custom styles for this template -->
   <link href="{{ "css/resume.css" | absURL }}" rel="stylesheet">
   <link href="{{ "css/tweaks.css" | absURL }}" rel="stylesheet">
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
   {{ block "headfiles" . }}
    <!-- pl;aceholder -->
   {{ end }}


### PR DESCRIPTION
Get rid of `.Hugo` function (soon to be deprecated) and replace with `hugo.` function