### PR TITLE
Fix blog post responsive width issue

### DIFF
--- a/static/css/tweaks.css
+++ b/static/css/tweaks.css
@@ -100,3 +100,8 @@ div.skills-heading{
     border-left: 4px solid #BD5D38;
     padding-left: 1em;
 }
+
+/* Fix responsive width for blog posts */
+.my-auto {
+	width: 100%
+}


### PR DESCRIPTION
Adding a width to the child element of the blog post fix an issue with the page 'overflowing' from the parent container.

Here you can see a post on your website with the problem:

![2019-05-17_width_overflow](https://user-images.githubusercontent.com/5703619/57945245-586e3580-78a7-11e9-9c50-fb44f8e0afc3.png)

and below what the fix accomplish:

![2019-05-17_without_width_overflow](https://user-images.githubusercontent.com/5703619/57945140-0fb67c80-78a7-11e9-9a1c-5bc15a7c42de.png)

I did not find the same issue on publications, projects nor opensource contributions pages.