### PR TITLE
Optional icon or link for Skills

### DIFF
--- a/exampleSite/data/skills.json
+++ b/exampleSite/data/skills.json
@@ -11,6 +11,15 @@
       "skills":[ "Atlassian","Bamboo","Bitbucket","NGINX","MySQL","Wordpress"]
   },
   {
+      "grouping":"Data Management",
+      "skills":[
+        {"name":"Microsoft SQL Server","icon":"msql_server"},
+        {"name":"Oracle","icon":"database"},
+        "MongoDB",
+        {"name":"Apache Spark"}
+      ]
+  },
+  {
     "grouping":"Containers & Cloud",
       "skills":[
           {"name":"BOSH","link":"https://bosh.io"},

--- a/layouts/partials/portfolio/skills.html
+++ b/layouts/partials/portfolio/skills.html
@@ -6,9 +6,14 @@
             <ul>
             {{ range .skills }}
                 {{ if isset . "name" }}
+                    {{ $devicon := cond (in $.Site.Data.devicons (lower .icon)) (lower .icon) (cond (in $.Site.Data.devicons (lower .name)) (lower .name) "terminal_badge") }}
                     <li class="list-inline-item">
-                      <i class="devicons devicons-{{ cond (in $.Site.Data.devicons (lower .name)) (lower .name) "terminal_badge" }}"></i>
-                      <a href="{{.link}}">{{ .name }}</a>
+                      <i class="devicons devicons-{{ $devicon }}"></i>
+                      {{if isset . "link"}}
+                          <a href="{{.link}}">{{ .name }}</a>
+                      {{ else }}
+                          {{ .name }}
+                      {{ end }}
                     </li>
                 {{ else }}
                   <li class="list-inline-item">


### PR DESCRIPTION
This provides flexibility for the Skills template so that one can override the icon and optionally specify a link for a skill.  This is particularly useful when you want to relabel the name from the icon code, or specify a better icon for a skill instead of relying on the default terminal badge.