### PR TITLE
Flexible names

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>{{ .Title }}</title>
-  <meta property="og:title" content="{{ .Title }}" />
+  <title>{{ .Site.Title }} | {{ .Title }}</title>
+  <meta property="og:title" content="{{ .Site.Title }} | {{ .Title }}" />
   <meta property="og:image" content="{{ .Site.Params.profileImage | absURL }}" />
-  <meta name="description" content="{{ .Site.Params.description }}">
-  <meta property="og:description" content="{{ .Site.Params.description }}" />
+  <meta name="description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{else}}{{ .Description }}{{ end }}">
+  <meta property="og:description" content="{{ if .IsHome }}{{ .Site.Params.description }}{{else}}{{ .Description }}{{ end }}" />
   <meta name="author" content="{{ .Site.Params.firstName }} {{ .Site.Params.lastName }}">
   <!-- Bootstrap core CSS -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -5,13 +5,13 @@
     <h1 id="{{ urlize .Title }}">{{ .Title }}</h1>
     <p>{{ .Content }}</p>
     {{ range .Data.Pages.ByWeight }}
-        {{ partial (printf "%s%s" .Section "Summary") . }}
+        {{ partial (printf "%s%s" .Type "Summary") . }}
     {{ end }}
     {{ range .Sections }}
       <h2 id="{{ urlize .Title }}"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
       <p>{{ .Content }}</p>
       {{ range .Pages }}
-        {{ partial (printf "%s%s" .Section "Summary") . }}
+        {{ partial (printf "%s%s" .Type "Summary") . }}
       {{ end }}
     {{ end }}
   </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
    {{ end }}
    {{ if .Site.Params.showPublications }}
       {{ with .Site.GetPage "section" "publications" }}
-         {{ .Scratch.Set "sectionId" "publications" }}
+         {{ .Scratch.Set "sectionId" (default "Publications" .Site.Params.publicationsAlternateName) }}
          {{ partial "sectionSummary" . }}
       {{ end }}
    {{ end }}

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -30,7 +30,7 @@
       {{ end }}
       {{ if .Site.Params.showPublications }}
           <li class="nav-item">
-            <a class="nav-link js-scroll-trigger" href="/#publications">Publications</a>
+            <a class="nav-link js-scroll-trigger" href="/#{{ default "Publications" .Site.Params.publicationsAlternateName }}">{{ default "Publications" .Site.Params.publicationsAlternateName }}</a>
           </li>
       {{ end }}
       {{ if .Site.Params.showExperience }}


### PR DESCRIPTION
This provides pattern for renaming sections without theme modificaton.

Currently only supports "publications" but allows url and display name to be changed site wide.


Example renaming to "presentations"
```toml
[params]
    ...
    showPublications = true
    publicationsAlternateName = "Presentations"
...
[permalinks]
  publications = "/presentations/:title/"
```