### PR TITLE
Fix raw HTML rendering (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ You can test the provided [exampleSite](exampleSite) after cloning with the comm
 `cd exampleSite;hugo -t hugo-resume --themesDir ../.. server`
 
 ### Summary
-Edit the main `contents/_index.md with a brief bio/summary`
+Edit the main `contents/_index.md with a brief bio/summary`  
+Requires the following in `config.toml` if using Hugo 0.60.0 or higher:
+```
+[markup.goldmark.renderer]
+unsafe = true
+```
 
 ### Data files
 Data files are used for simple content presented on the homepage.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -53,3 +53,6 @@ home = ["HTML", "JSON"]
 
 [taxonomies]
 tag = "tags"
+
+[markup.goldmark.renderer]
+unsafe = true


### PR DESCRIPTION
Fixes #49, when using the Goldmark markdawn library(default in >=0.60.0), Hugo will ignore raw HTML unless 
```
[markup.goldmark.renderer]
unsafe = true
```
is set in `config.toml`.