### PR TITLE
Fix scrollspy error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.iml
+.idea

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -47,6 +47,7 @@
   </div>
   <!-- Bootstrap core JavaScript -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.min.js"></script>
   <script async src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
 
   <!-- Plugin JavaScript -->


### PR DESCRIPTION
Hello,

This PR fixes the `TypeError: $(...).scrollspy is not a function` error that currently occurs because of Bootstrap 4 (see https://stackoverflow.com/a/54139615).

