### PR TITLE
Popper fix. Resolves #62.

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -23,7 +23,7 @@
           <ul class="list-inline list-social-icons mb-0">
             {{ range .Site.Params.handles }}
                 <li class="list-inline-item">
-                  <a href="{{ .link }}" data-toggle="tooltip" title="{{ .name }}" data-offset="0 10" rel="me">
+                  <a href="{{ .link }}" data-toggle="tooltip" title="{{ .name }}" data-offset="0,10" rel="me">
                     <span class="fa-stack fa-lg">
                       <i class="fa fa-circle fa-stack-2x"></i>
                       <i class="fab {{ if .icon}}fa-{{ .icon }}{{ else }}fa-{{ lower .name }}{{ end }} fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
> Offsets separated by white space(s) are deprecated, use a comma (,) instead.