### PR TITLE
Fix deprecation warning when running example site (hugo 0.156.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .hugo_build.lock
+public/

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -36,7 +36,7 @@
           {{ if .Site.Params.showCertifications }}
           <h3 class="mt-3">{{ i18n "certifications" }}</h3>
           <ul class="list-inline list-social-icons mb-0">
-            {{ range .Site.Data.certifications }}
+            {{ range hugo.Data.certifications }}
                 <li class="list-inline-item">
                   <a href="{{ .proof }}" data-toggle="tooltip" title="{{ .name }}" data-offset="0 10" rel="me">
                     <img src="{{ .badge }}" width=75 />
@@ -48,7 +48,7 @@
           {{ if .Site.Params.showBoards }}
           <h3 class="mt-3 mb-0">{{ i18n "boards" }}</h3>
           <ul class="list-inline list-social-icons mb-0 mt-0">
-            {{ range .Site.Data.boards }}
+            {{ range hugo.Data.boards }}
                 <li class="list-inline-item mt-0">
                   <div class="mt-0 text-center" data-toggle="tooltip" title="{{ .description }}" data-offset="-30 -30">
                     <a href="{{ .url }}" rel="external">

--- a/layouts/partials/portfolio/education.html
+++ b/layouts/partials/portfolio/education.html
@@ -1,7 +1,7 @@
         <section class="resume-section p-3 p-lg-5 d-flex flex-column" id="education">
           <div class="my-auto">
           <h2 class="mb-5">{{ i18n "education" }}</h2>
-            {{ range $.Data.education }}
+            {{ range hugo.Data.education }}
               <div class="resume-item d-flex flex-column flex-md-row mb-5">
                 <div class="resume-content mr-auto">
                   <h3 class="mb-0">{{ .school | markdownify }}</h3>

--- a/layouts/partials/portfolio/experience.html
+++ b/layouts/partials/portfolio/experience.html
@@ -1,7 +1,7 @@
 <section class="resume-section p-3 p-lg-5 d-flex flex-column" id="experience">
   <div class="my-auto" id="experience-content">
   <h2 class="mb-5">{{ i18n "experience" }}</h2>
-    {{ range $.Data.experience }}
+    {{ range hugo.Data.experience }}
         <div class="resume-item d-flex flex-column flex-md-row mb-5">
           <div class="resume-content mr-auto">
             <h3 class="mb-0">{{ .role }}</h3>

--- a/layouts/partials/portfolio/skills.html
+++ b/layouts/partials/portfolio/skills.html
@@ -1,8 +1,7 @@
 <section class="resume-section p-3 p-lg-5 d-flex flex-column" id="skills">
   <div class="my-auto" id="skills-content">
   <h2 class="mb-5">{{ i18n "skills" }}</h2>
-    {{ $data := $.Data }}
-    {{ range $data.skills }}
+    {{ range hugo.Data.skills }}
         <div class="subheading mb-3 skills-heading">{{ .grouping }}</div>
             <ul>
             {{ range .skills }}

--- a/layouts/partials/vcard.html
+++ b/layouts/partials/vcard.html
@@ -19,7 +19,7 @@ EMAIL;TYPE=INTERNET,WORK:{{ .Param "workemail" }}
 PHOTO;TYPE=JPG;VALUE=URI:{{ .Site.BaseURL }}{{ .Site.Params.profileImage }}
 {{ end }}
 {{ if in $fields "org" }}
-ORG:{{ range first 1 .Site.Data.experience }}{{ .company }}{{ end }}
+ORG:{{ range first 1 hugo.Data.experience }}{{ .company }}{{ end }}
 {{ end }}
 {{ if in $fields "title" }}
 TITLE:{{ .Site.Params.contactNote }}


### PR DESCRIPTION
When running the example site with latest released hugo version 0.156.0, a deprecation warning is printed out:
```
INFO  deprecated: .Site.Languages was deprecated in Hugo v0.156.0
and will be removed in a future release.
See https://discourse.gohugo.io/t/56732.
```

This PR fixes this issue.